### PR TITLE
Hush Windows Warnings

### DIFF
--- a/cola/libavoid/router.cpp
+++ b/cola/libavoid/router.cpp
@@ -1278,7 +1278,7 @@ class CrossingConnectorsInfo
             connSet.clear();
 
             // Return the candidate connector and its original crossing count.
-            return std::make_pair(candidateCrossingCount, candidateConnector);
+            return std::make_pair(static_cast<double>(candidateCrossingCount), candidateConnector);
         }
 
         // Returns the iterator to the group that the given conn is in,

--- a/cola/libcola/connected_components.cpp
+++ b/cola/libcola/connected_components.cpp
@@ -71,7 +71,7 @@ namespace cola {
                 map<unsigned,pair<Component*,unsigned> > &cmap) {
             v->visited=true;
             remaining.erase(v->listPos);
-            cmap[v->id]=make_pair(component,component->node_ids.size());
+            cmap[v->id]=make_pair(component,static_cast<unsigned>(component->node_ids.size()));
             component->node_ids.push_back(v->id);
             component->rects.push_back(v->r);
             for(unsigned i=0;i<v->neighbours.size();i++) {


### PR DESCRIPTION
Windows warns about narrowing conversions, even though we know they should be safe. Hush those warnings.